### PR TITLE
Raname Sentry package dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "raven/raven": ">=0.8.0"
+        "sentry/sentry": ">=0.8.0"
     },
     "require-dev": {
         "yiisoft/yii": ">=1.1.14"


### PR DESCRIPTION
Package raven/raven is deprecated, switched to the sentry-php package. cf. https://github.com/getsentry/raven-php
